### PR TITLE
HOTFIX: missing reactions from _add_sequence fixed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cobramod",
-    version="0.0.1a0",
+    version="0.1.1",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     package_data={"": ["data/*"]},

--- a/src/cobramod/__init__.py
+++ b/src/cobramod/__init__.py
@@ -5,7 +5,7 @@ from cobramod.creation import (
     add_reactions_from_file,
     meta_string_to_model,
 )
-from cobramod.extension import add_graph_to_model
+from cobramod.extension import add_pathway, test_result
 from cobramod.pathway import Pathway
 from cobramod.utils import model_convert
 
@@ -15,8 +15,11 @@ __all__ = [
     "add_meta_from_file",
     "add_reactions_from_file",
     "meta_string_to_model",
-    "add_graph_to_model",
+    "add_pathway",
+    "test_result",
     "Pathway",
     "translate",
     "model_convert",
 ]
+
+__version__ = "0.1.1"

--- a/tests/extra/creating_test_model.py
+++ b/tests/extra/creating_test_model.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import cobra as cb
 from pathlib import Path
-from cobramod.extension import add_graph_to_model
+from cobramod.extension import add_pathway
 from cobramod.creation import (
     add_meta_from_file,
     add_reactions_from_file,
@@ -51,9 +51,9 @@ for meta in test_model.metabolites:
 test_model.objective = "EX_WATER_e"
 # First pathway to create a proper dummy biomass reaction
 # Nitrate reduction
-add_graph_to_model(
+add_pathway(
     model=test_model,
-    graph="PWY-381",
+    pathway="PWY-381",
     directory=dir_data,
     database="META",
     compartment="c",
@@ -78,9 +78,9 @@ for pathway in [
     "PWY-5690",  # TCA cycle
     "PYRUVDEHYD-PWY",
 ]:
-    add_graph_to_model(
+    add_pathway(
         model=test_model,
-        graph=pathway,
+        pathway=pathway,
         directory=dir_data,
         database="META",
         compartment="c",
@@ -91,9 +91,9 @@ test_model.reactions.get_by_id("Biomass_c").add_metabolites(
     {test_model.metabolites.get_by_id("GLT_c"): -1}
 )
 for pathway in ["CALVIN-PWY"]:
-    add_graph_to_model(
+    add_pathway(
         model=test_model,
-        graph=pathway,
+        pathway=pathway,
         directory=dir_data,
         database="META",
         compartment="c",
@@ -101,9 +101,9 @@ for pathway in ["CALVIN-PWY"]:
     )
 
 for pathway in ["SUCSYN-PWY"]:
-    add_graph_to_model(
+    add_pathway(
         model=test_model,
-        graph=pathway,
+        pathway=pathway,
         directory=dir_data,
         database="META",
         compartment="c",

--- a/tests/test_glucosinolate.py
+++ b/tests/test_glucosinolate.py
@@ -134,9 +134,9 @@ class GlucosinolateTest(unittest.TestCase):
 
     def test_B_precursors(self):
         # Glutathione synthesis
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph="GLUTATHIONESYN-PWY",
+            pathway="GLUTATHIONESYN-PWY",
             database="ARA",
             directory=dir_data,
             compartment="p",
@@ -144,9 +144,9 @@ class GlucosinolateTest(unittest.TestCase):
         )
         # Original has an extra demand (total 962)
         self.assertEqual(len(test_model.reactions), 961)
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph="PWY-5340",
+            pathway="PWY-5340",
             database="ARA",
             directory=dir_data,
             compartment="p",
@@ -157,9 +157,9 @@ class GlucosinolateTest(unittest.TestCase):
         # One reaction was already in model
         self.assertEqual(len(test_model.reactions), 962)
         # Homomethionine synthesis
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph="PWY-1186",
+            pathway="PWY-1186",
             database="ARA",
             directory=dir_data,
             compartment="p",
@@ -170,9 +170,9 @@ class GlucosinolateTest(unittest.TestCase):
         # Its counterpart in cytosol was added from the file
         self.assertNotIn("R15_RXN_p", [rxn.id for rxn in test_model.reactions])
         # Methionine Elogation chain
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph="PWYQT-4450",
+            pathway="PWYQT-4450",
             database="ARA",
             directory=dir_data,
             compartment="p",
@@ -184,9 +184,9 @@ class GlucosinolateTest(unittest.TestCase):
 
     def test_C_aliphatic(self):
         # From Homomethionine
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph=[
+            pathway=[
                 "RXN-11422",
                 "RXN-11430",
                 "RXN-11438",
@@ -203,9 +203,9 @@ class GlucosinolateTest(unittest.TestCase):
         )
         self.assertGreater(test_model.slim_optimize(), 0)
         # From Dihomemethionine
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph=[
+            pathway=[
                 "RXN-11423",
                 "RXN-11431",
                 "RXN-11439",
@@ -222,9 +222,9 @@ class GlucosinolateTest(unittest.TestCase):
         )
         self.assertGreater(test_model.slim_optimize(), 0)
         # From Trihomomethionine
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph=[
+            pathway=[
                 "RXN-11424",
                 "RXN-11432",
                 "RXN-11440",
@@ -241,9 +241,9 @@ class GlucosinolateTest(unittest.TestCase):
         )
         self.assertGreater(test_model.slim_optimize(), 0)
         # From Tetrahomomethionine
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph="PWYQT-4473",
+            pathway="PWYQT-4473",
             database="ARA",
             directory=dir_data,
             compartment="c",
@@ -253,9 +253,9 @@ class GlucosinolateTest(unittest.TestCase):
         )
         self.assertGreater(test_model.slim_optimize(), 0)
         # From Pentahomomethionine
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph="PWYQT-4474",
+            pathway="PWYQT-4474",
             database="ARA",
             directory=dir_data,
             compartment="c",
@@ -265,9 +265,9 @@ class GlucosinolateTest(unittest.TestCase):
         )
         self.assertGreater(test_model.slim_optimize(), 0)
         # From Hexahomomethionine
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph="PWYQT-4475",
+            pathway="PWYQT-4475",
             database="ARA",
             directory=dir_data,
             compartment="c",
@@ -283,9 +283,9 @@ class GlucosinolateTest(unittest.TestCase):
         test_model.metabolites.get_by_id(meta).formula = "C15H23N6O5S"
         test_model.metabolites.get_by_id(meta).charge = 1
         # From Tryptophan
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph="PWY-601",
+            pathway="PWY-601",
             database="ARA",
             directory=dir_data,
             compartment="c",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -38,9 +38,9 @@ class TestingShortModel(unittest.TestCase):
             test_model.metabolites.get_by_id("ATP_c"), "sink"
         )
         # Adding Gluconeogenesis
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph="GLUCONEO-PWY",
+            pathway="GLUCONEO-PWY",
             directory=dir_data,
             database="META",
             compartment="c",
@@ -61,9 +61,9 @@ class TestingShortModel(unittest.TestCase):
             database="META",
         )
         # Adding Nicotine pathway
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph="PWY-5316",
+            pathway="PWY-5316",
             directory=dir_data,
             database="META",
             compartment="c",
@@ -74,9 +74,9 @@ class TestingShortModel(unittest.TestCase):
             container=[group.id for group in test_model.groups],
         )
         # Ading aspartate and asparagine biosynthesis
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph="ASPASN-PWY",
+            pathway="ASPASN-PWY",
             directory=dir_data,
             database="META",
             compartment="c",
@@ -92,9 +92,9 @@ class TestingShortModel(unittest.TestCase):
         # test_model = main_model1.copy()
         test_model = textbook_biocyc.copy()
         # Adding Mannitol cycle
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph="PWY-6531",
+            pathway="PWY-6531",
             directory=dir_data,
             database="META",
             compartment="c",
@@ -105,9 +105,9 @@ class TestingShortModel(unittest.TestCase):
             container=[group.id for group in test_model.groups],
         )
         # Adding glyoxylate cycle
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph="GLYOXYLATE-BYPASS",
+            pathway="GLYOXYLATE-BYPASS",
             directory=dir_data,
             database="META",
             compartment="c",
@@ -133,9 +133,9 @@ class TestingShortModel(unittest.TestCase):
             metabolite=test_model.metabolites.get_by_id("CO_A_e"),
             type="exchange",
         )
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph="GLUTATHIONESYN-PWY",
+            pathway="GLUTATHIONESYN-PWY",
             directory=dir_data,
             database="META",
             ignore_list=[],
@@ -155,9 +155,9 @@ class TestingShortModel(unittest.TestCase):
             directory=dir_data,
             database="META",
         )
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph="PWY-1187",
+            pathway="PWY-1187",
             directory=dir_data,
             database="META",
             ignore_list=["PYRUVATE_c", "CO_A_c", "PROTON_c", "CPD_3746_c"],
@@ -173,9 +173,9 @@ class TestingShortModel(unittest.TestCase):
         )
         self.assertGreater(abs(test_model.optimize().objective_value), 0)
         # Lipid initalization
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph="PWY-4381",
+            pathway="PWY-4381",
             directory=dir_data,
             database="META",
             ignore_list=["CO_A_p"],
@@ -209,9 +209,9 @@ class TestingLargeModel(unittest.TestCase):
             type="sink",
         )
         # Adding methiin metabolism
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph="PWY-7614",
+            pathway="PWY-7614",
             directory=dir_data,
             database="META",
             compartment="p",
@@ -226,9 +226,9 @@ class TestingLargeModel(unittest.TestCase):
         self.assertGreater(test_model.optimize().fluxes["DM_CPD_9277_p"], 0)
         self.assertGreater(test_model.optimize().fluxes["RXN_8908_p"], 0)
         # Adding stachyose biosynthesis
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph="PWY-5337",
+            pathway="PWY-5337",
             directory=dir_data,
             database="META",
             compartment="c",
@@ -247,9 +247,9 @@ class TestingLargeModel(unittest.TestCase):
             metabolite=test_model.metabolites.get_by_id("CPD1F_133_p"),
             type="sink",
         )
-        ex.add_graph_to_model(
+        ex.add_pathway(
             model=test_model,
-            graph="PWY-695",
+            pathway="PWY-695",
             directory=dir_data,
             database="META",
             compartment="p",


### PR DESCRIPTION
*INFO*: the function _add_sequence was skipping ignored reactions and breaking the model when using cobrapy built-in functions. Now, reactions from the sequences will be added from the for loop instead of
using the whole list.
**NEW**: argument ignore_list will skip TESTING reactions. avoid_list will avoid adding them into the model.
*UPDATED*: function add_graph_to_model renamed to add_pathway, test_solution renamed to test_result. _r_metabolite_boundary renamed to _remove boundary. Multiple comments added to functions. Docstring for
module added.
Cobramod version updated to 0.1.1.
*UPDATED*: \_\_init\_\_ now import test_result and contains \_\_version\_\_.
*UPDATED*: all test have been updated with mentioned changes.