### PR TITLE
Fix: Custom metabolites and reactions. Single-reaction pathways

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cobramod",
-    version="0.1.5",
+    version="0.1.6",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     package_data={"": ["data/*"]},

--- a/src/cobramod/__init__.py
+++ b/src/cobramod/__init__.py
@@ -54,4 +54,4 @@ __all__ = [
     "available_databases",
 ]
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"

--- a/src/cobramod/core/creation.py
+++ b/src/cobramod/core/creation.py
@@ -839,7 +839,7 @@ def __add_metabolites_check(model: Model, metabolites: List[Metabolite]):
         )
 
 
-def add_metabolites(model: Model, obj: Any, **kwargs):
+def add_metabolites(model: Model, obj: Any, database=None, **kwargs):
     """
     Adds given object into the model. The options are:
 
@@ -865,11 +865,12 @@ def add_metabolites(model: Model, obj: Any, **kwargs):
         model (Model): Model to expand and search for metabolites.
         obj: A Path; a list with either strings or Metabolite objects,
             or a single string. See syntax above.
+        database (str): Name of database. Check
+            :obj:`cobramod.available_databases` for a list of names. Defaults
+            to None (This is useful for custom metabolites).
 
     Keyword Arguments:
         directory (Path): Path to directory where data is located.
-        database (str): Name of database. Check
-            :obj:`cobramod.available_databases` for a list of names.
 
     Raises:
         WrongSyntax (from str): If syntax is not followed correctly as
@@ -882,7 +883,6 @@ def add_metabolites(model: Model, obj: Any, **kwargs):
         if isinstance(obj, Path):
             # These variable will raise KeyError if no kwargs are passed.
             directory = kwargs["directory"]
-            database = kwargs["database"]
             new_metabolites = _get_file_metabolites(
                 # as Path
                 filename=obj,
@@ -902,7 +902,6 @@ def add_metabolites(model: Model, obj: Any, **kwargs):
         ):
             # These variable will raise KeyError if no kwargs are passed.
             directory = kwargs["directory"]
-            database = kwargs["database"]
             # Make a list
             if isinstance(obj, str):
                 obj = [obj]
@@ -947,7 +946,7 @@ def __add_reactions_check(model: Model, reactions: List[Reaction]):
         )
 
 
-def add_reactions(model: Model, obj: Any, **kwargs):
+def add_reactions(model: Model, obj: Any, database=None, **kwargs):
     """Adds given object into the model. The options are:
 
      - Path: A file with components. E. g:
@@ -976,11 +975,12 @@ def add_reactions(model: Model, obj: Any, **kwargs):
         model (Model): Model to expand and search for reactions.
         obj: A Path; a list with either strings or Reaction objects,
             or a single string. See syntax above.
+        database (str): Name of database. Check
+            :obj:`cobramod.available_databases` for a list of names. Defaults
+            to None (Useful for custom reactions).
 
     Keyword Arguments:
         directory (Path): Path to directory where data is located.
-        database (str): Name of database. Check
-            :obj:`cobramod.available_databases` for a list of names.
         replacement (dict): original identifiers to be replaced.
             Values are the new identifiers. Defaults to {}.
 
@@ -995,7 +995,6 @@ def add_reactions(model: Model, obj: Any, **kwargs):
         if isinstance(obj, Path):
             # These variable will raise KeyError if no kwargs are passed.
             directory = kwargs["directory"]
-            database = kwargs["database"]
             # Empty dictionary is nothing assigned
             replacement = kwargs.pop("replacement", dict())
             new_reactions = _get_file_reactions(
@@ -1016,7 +1015,6 @@ def add_reactions(model: Model, obj: Any, **kwargs):
             obj, str
         ):
             directory = kwargs["directory"]
-            database = kwargs["database"]
             # Empty dictionary is nothing assigned
             replacement = kwargs.pop("replacement", dict())
             # Make a list

--- a/src/cobramod/core/retrieval.py
+++ b/src/cobramod/core/retrieval.py
@@ -10,6 +10,8 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Type
 
+from requests import HTTPError
+
 from cobramod.error import WrongParserError, PatternNotFound
 from cobramod.parsing.base import BaseParser
 from cobramod.parsing.biocyc import BiocycParser
@@ -64,6 +66,8 @@ def get_data(
     Returns:
         dict: relevant data for given identifier
     """
+    if database is None:
+        raise HTTPError
     real_parser = _get_parser(database=database)
     return real_parser._retrieve_data(
         directory=directory,

--- a/tests/data/META/PWY-7344.xml
+++ b/tests/data/META/PWY-7344.xml
@@ -1,0 +1,248 @@
+<ptools-xml ptools-version="24.5" xml:base="http://BioCyc.org/getxml?META:PWY-7344"><metadata><url>http://BioCyc.org/</url>
+<service_name>getxml</service_name>
+<query>META:PWY-7344</query>
+<num_results>1</num_results>
+<PGDB orgid="META" version="24.5"><species datatype="string">MetaCyc</species>
+</PGDB>
+</metadata>
+<Pathway ID="META:PWY-7344" detail="full" frameid="PWY-7344" orgid="META"><parent><Pathway class="true" frameid="UDP-Sugar-Biosynthesis" orgid="META" resource="getxml?META:UDP-Sugar-Biosynthesis" /></parent>
+<evidence><Evidence-Code ID="META:EV-EXP-IDA" class="true" detail="full" frameid="EV-EXP-IDA" orgid="META"><parent><Evidence-Code class="true" frameid="EV-EXP" orgid="META" resource="getxml?META:EV-EXP" /></parent>
+<comment datatype="string">IDA inferred from direct assay.
+
+&lt;br&gt;
+The assertion was inferred from a direct experimental assay such as
+&lt;ul&gt;
+    &lt;li&gt; Enzyme assays
+    &lt;li&gt; In vitro reconstitution (e.g. transcription)
+    &lt;li&gt; Immunofluorescence
+    &lt;li&gt; Cell fractionation
+&lt;/ul&gt;</comment>
+<common-name datatype="string">Inferred from direct assay</common-name>
+</Evidence-Code>
+<Publication ID="META:PUB-8615692" detail="full" frameid="PUB-8615692" orgid="META"><author datatype="string">Dormann P</author>
+<author datatype="string">Benning C</author>
+<pubmed-id datatype="string">8615692</pubmed-id>
+<source datatype="string">Arch Biochem Biophys 327(1);27-34</source>
+<title datatype="string">Functional expression of uridine 5'-diphospho-glucose 4-epimerase (EC 5.1.3.2) from Arabidopsis thaliana in Saccharomyces cerevisiae and Escherichia coli.</title>
+<year datatype="integer">1996</year>
+</Publication>
+</evidence>
+<evidence><Evidence-Code class="true" frameid="EV-EXP-IDA" orgid="META" resource="#META:EV-EXP-IDA" /><Publication ID="META:PUB-9692181" detail="full" frameid="PUB-9692181" orgid="META"><author datatype="string">Weston A</author>
+<author datatype="string">Stern RJ</author>
+<author datatype="string">Lee RE</author>
+<author datatype="string">Nassau PM</author>
+<author datatype="string">Monsey D</author>
+<author datatype="string">Martin SL</author>
+<author datatype="string">Scherman MS</author>
+<author datatype="string">Besra GS</author>
+<author datatype="string">Duncan K</author>
+<author datatype="string">McNeil MR</author>
+<pubmed-id datatype="string">9692181</pubmed-id>
+<source datatype="string">Tuber Lung Dis 78(2);123-31</source>
+<title datatype="string">Biosynthetic origin of mycobacterial cell wall galactofuranosyl residues.</title>
+<year datatype="integer">1997</year>
+</Publication>
+</evidence>
+<comment datatype="string">&lt;a href="/compound?orgid=META&amp;id=CPD-14553"&gt;UDP-&amp;alpha;-D-galactose&lt;/a&gt; is the activated form of &lt;a href="/META/NEW-IMAGE?type=COMPOUND&amp;object=D-galactopyranose"&gt;D-galactopyranose&lt;/a&gt;. While it is often produced as an intermediate of galactose catabolism (see &lt;a href="/META/NEW-IMAGE?type=PATHWAY&amp;object=PWY-6317"&gt;D-galactose degradation I (Leloir pathway)&lt;/a&gt;), this nucleotide sugar is also involved in the production of many types of polysaccharides, glycans, and glycoconjugates in both prokaryotes and eukaryotes.
+&lt;p&gt;
+In prokaryotes, &lt;a href="/compound?orgid=META&amp;id=CPD-14553"&gt;UDP-&amp;alpha;-D-galactose&lt;/a&gt; is a common precursor for O-antigens and S-layer polysaccharides (see &lt;a href="/META/NEW-IMAGE?type=PATHWAY&amp;object=PWY-7328"&gt;superpathway of UDP-glucose-derived O-antigen building blocks biosynthesis&lt;/a&gt;), protein glycosylation (see for example &lt;a href="/META/NEW-IMAGE?type=PATHWAY&amp;object=PWY-7037"&gt;protein &lt;i&gt;O&lt;/i&gt;-glycosylation (Neisseria)&lt;/a&gt;) and cell wall polymers (see &lt;a href="/META/NEW-IMAGE?type=PATHWAY&amp;object=PWY-6397"&gt;mycolyl-arabinogalactan-peptidoglycan complex biosynthesis&lt;/a&gt;).
+&lt;p&gt;
+A few examples for eukaryotic polysaccharides whose biosynthesis requires &lt;a href="/compound?orgid=META&amp;id=CPD-14553"&gt;UDP-&amp;alpha;-D-galactose&lt;/a&gt; include xyloglucans (&lt;a href="/META/NEW-IMAGE?type=PATHWAY&amp;object=PWY-5936"&gt;xyloglucan biosynthesis&lt;/a&gt;), glycolipids (&lt;a href="/META/NEW-IMAGE?type=PATHWAY&amp;object=PWY-401"&gt;galactolipid biosynthesis I&lt;/a&gt;), glycosaminoglycans (&lt;a href="/META/NEW-IMAGE?type=PATHWAY&amp;object=PWY-6557"&gt;glycosaminoglycan-protein linkage region biosynthesis&lt;/a&gt;), glycoalkaloids (&lt;a href="/META/NEW-IMAGE?type=PATHWAY&amp;object=PWY-5666"&gt;&amp;alpha;-solanine/&amp;alpha;-chaconine biosynthesis&lt;/a&gt;), fagopyritols (&lt;a href="/META/NEW-IMAGE?type=PATHWAY&amp;object=PWY-5380"&gt;A series fagopyritols biosynthesis&lt;/a&gt;) and saponins (&lt;a href="/META/NEW-IMAGE?type=PATHWAY&amp;object=PWY-5203"&gt;soybean saponin I biosynthesis&lt;/a&gt;).</comment>
+<common-name datatype="string">UDP-&amp;alpha;-D-galactose biosynthesis</common-name>
+<credits><created><date datatype="date">2013-08-15</date>
+<Person ID="META:caspi" detail="full" frameid="caspi" orgid="META"><comment datatype="string">Ron Caspi has been a curator of the MetaCyc database at SRI International since 2005.</comment>
+<common-name datatype="string">Ron Caspi</common-name>
+<email datatype="string">caspi@ai.sri.com</email>
+<affiliations><Organization ID="META:SRI" detail="full" frameid="SRI" orgid="META"><common-name datatype="string">SRI International</common-name>
+<email datatype="string">ptools-support@ai.sri.com</email>
+<url datatype="string">http://bioinformatics.ai.sri.com/</url>
+<abbrev-name datatype="string">SRI International</abbrev-name>
+</Organization>
+</affiliations>
+</Person>
+<Organization frameid="SRI" orgid="META" resource="#META:SRI" /></created>
+</credits>
+<dblink><dblink-db>ECOCYC</dblink-db>
+<dblink-oid>PWY-7344</dblink-oid>
+<dblink-relationship>unification</dblink-relationship>
+<dblink-URL>http://biocyc.org/ECOLI/new-image?object=PWY-7344</dblink-URL>
+</dblink>
+<in-pathway><Pathway frameid="PWY-7622" orgid="META" resource="getxml?META:PWY-7622" /><Pathway frameid="PWY-5114" orgid="META" resource="getxml?META:PWY-5114" /><Pathway frameid="COLANSYN-PWY" orgid="META" resource="getxml?META:COLANSYN-PWY" /><Pathway frameid="PWY-7328" orgid="META" resource="getxml?META:PWY-7328" /></in-pathway>
+<pathway-link><Compound frameid="CPD-12575" orgid="META" resource="getxml?META:CPD-12575" /><link-target><Pathway frameid="PWY-7343" orgid="META" resource="getxml?META:PWY-7343" /></link-target>
+</pathway-link>
+<reaction-layout><Reaction frameid="UDPGLUCEPIM-RXN" orgid="META" resource="getxml?META:UDPGLUCEPIM-RXN" /><direction>L2R</direction>
+<left-primaries><Compound frameid="CPD-12575" orgid="META" resource="getxml?META:CPD-12575" /></left-primaries>
+<right-primaries><Compound frameid="CPD-14553" orgid="META" resource="getxml?META:CPD-14553" /></right-primaries>
+</reaction-layout>
+<reaction-list><Reaction frameid="UDPGLUCEPIM-RXN" orgid="META" resource="getxml?META:UDPGLUCEPIM-RXN" /></reaction-list>
+<species><Organism ID="META:TAX-1423" class="true" detail="full" frameid="TAX-1423" orgid="META"><parent><Organism class="true" frameid="TAX-653685" orgid="META" resource="getxml?META:TAX-653685" /></parent>
+<common-name datatype="string">Bacillus subtilis</common-name>
+<dblink><dblink-db>NCBI-TAXONOMY-DB</dblink-db>
+<dblink-oid>1423</dblink-oid>
+<dblink-relationship>unification</dblink-relationship>
+<dblink-URL>http://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&amp;id=1423</dblink-URL>
+</dblink>
+<rank>species</rank>
+<synonym datatype="string">Vibrio subtilis</synonym>
+<synonym datatype="string">Brevibacillus sp. BHR3P2B5-M</synonym>
+<synonym datatype="string">Bacillus uniflagellatus</synonym>
+<synonym datatype="string">Bacillus sp. UMX-03</synonym>
+<synonym datatype="string">Bacillus sp. SWI06</synonym>
+<synonym datatype="string">Bacillus sp. S2 BC-1</synonym>
+<synonym datatype="string">Bacillus sp. RSP-GLU</synonym>
+<synonym datatype="string">Bacillus sp. PW19</synonym>
+<synonym datatype="string">Bacillus sp. PW16b</synonym>
+<synonym datatype="string">Bacillus sp. LKM-BL</synonym>
+<synonym datatype="string">Bacillus sp. LB002</synonym>
+<synonym datatype="string">Bacillus sp. JKR21</synonym>
+<synonym datatype="string">Bacillus sp. HE08</synonym>
+<synonym datatype="string">Bacillus sp. BV5</synonym>
+<synonym datatype="string">Bacillus sp. BV3</synonym>
+<synonym datatype="string">Bacillus sp. BS9(2013)</synonym>
+<synonym datatype="string">Bacillus sp. BS4(2013)</synonym>
+<synonym datatype="string">Bacillus sp. AECSB14</synonym>
+<synonym datatype="string">Bacillus sp. AECSB13</synonym>
+<synonym datatype="string">Bacillus sp. AECSB12</synonym>
+<synonym datatype="string">Bacillus sp. AECSB08</synonym>
+<synonym datatype="string">Bacillus sp. AECSB07</synonym>
+<synonym datatype="string">Bacillus sp. AECSB06</synonym>
+<synonym datatype="string">Bacillus sp. AECSB05</synonym>
+<synonym datatype="string">Bacillus sp. AECSB04</synonym>
+<synonym datatype="string">Bacillus sp. AECSB01</synonym>
+<synonym datatype="string">Bacillus sp. 15:2</synonym>
+<synonym datatype="string">Bacillus sp. 10405</synonym>
+<synonym datatype="string">Bacillus natto</synonym>
+<synonym datatype="string">Arthrobacter sp. CHR2P1B1-M</synonym>
+</Organism>
+</species>
+<species><Organism ID="META:TAX-511145" class="true" detail="full" frameid="TAX-511145" orgid="META"><parent><Organism class="true" frameid="TAX-83333" orgid="META" resource="getxml?META:TAX-83333" /></parent>
+<citation><Publication ID="META:PUB-23143106" detail="full" frameid="PUB-23143106" orgid="META"><author datatype="string">Keseler IM</author>
+<author datatype="string">Mackie A</author>
+<author datatype="string">Peralta-Gil M</author>
+<author datatype="string">Santos-Zavaleta A</author>
+<author datatype="string">Gama-Castro S</author>
+<author datatype="string">Bonavides-Martinez C</author>
+<author datatype="string">Fulcher C</author>
+<author datatype="string">Huerta AM</author>
+<author datatype="string">Kothari A</author>
+<author datatype="string">Krummenacker M</author>
+<author datatype="string">Latendresse M</author>
+<author datatype="string">Muniz-Rascado L</author>
+<author datatype="string">Ong Q</author>
+<author datatype="string">Paley S</author>
+<author datatype="string">Schroder I</author>
+<author datatype="string">Shearer AG</author>
+<author datatype="string">Subhraveti P</author>
+<author datatype="string">Travers M</author>
+<author datatype="string">Weerasinghe D</author>
+<author datatype="string">Weiss V</author>
+<author datatype="string">Collado-Vides J</author>
+<author datatype="string">Gunsalus RP</author>
+<author datatype="string">Paulsen I</author>
+<author datatype="string">Karp PD</author>
+<pubmed-id datatype="string">23143106</pubmed-id>
+<source datatype="string">Nucleic Acids Res 41(Database issue);D605-12</source>
+<title datatype="string">EcoCyc: fusing model organism databases with systems biology.</title>
+<year datatype="integer">2013</year>
+</Publication>
+</citation>
+<comment datatype="string">EcoCyc is a model-organism database for &lt;i&gt;Escherichia coli&lt;/i&gt; K-12 MG1655.  For more information, see URL EcoCyc.org.
+&lt;p&gt;
+The &lt;i&gt;E. coli&lt;/i&gt; genome sequence used in EcoCyc is GenBank accession number U00096.2.  Despite the
+involvement of EcoCyc staff in ongoing updates to the U00096 record, some annotation differences may
+be found between U00096 and EcoCyc, such as due to recent updates to EcoCyc.
+</comment>
+<common-name datatype="string">Escherichia coli</common-name>
+<dblink><dblink-db>NCBI-TAXONOMY-DB</dblink-db>
+<dblink-oid>511145</dblink-oid>
+<dblink-relationship>unification</dblink-relationship>
+<dblink-URL>http://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&amp;id=511145</dblink-URL>
+</dblink>
+<rank>strain</rank>
+<strain-name datatype="string">K-12 substr. MG1655</strain-name>
+<synonym datatype="string">Escherichia coli str. K-12 substr. MG1655</synonym>
+<synonym datatype="string">Escherichia coli str. MG1655</synonym>
+<synonym datatype="string">Escherichia coli str. K12 substr. MG1655</synonym>
+<synonym datatype="string">Escherichia coli strain MG1655</synonym>
+<synonym datatype="string">Escherichia coli MG1655</synonym>
+</Organism>
+</species>
+<species><Organism ID="META:TAX-9606" class="true" detail="full" frameid="TAX-9606" orgid="META"><parent><Organism class="true" frameid="TAX-9605" orgid="META" resource="getxml?META:TAX-9605" /></parent>
+<comment datatype="string">The HumanCyc project is described at URL  http://HumanCyc.org/</comment>
+<common-name datatype="string">Homo sapiens</common-name>
+<dblink><dblink-db>NCBI-TAXONOMY-DB</dblink-db>
+<dblink-oid>9606</dblink-oid>
+<dblink-relationship>unification</dblink-relationship>
+<dblink-URL>http://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&amp;id=9606</dblink-URL>
+</dblink>
+<rank>species</rank>
+<synonym datatype="string">man</synonym>
+<synonym datatype="string">human</synonym>
+</Organism>
+</species>
+<species><Organism ID="META:TAX-83332" class="true" detail="full" frameid="TAX-83332" orgid="META"><parent><Organism class="true" frameid="TAX-1773" orgid="META" resource="getxml?META:TAX-1773" /></parent>
+<common-name datatype="string">Mycobacterium tuberculosis</common-name>
+<dblink><dblink-db>NCBI-TAXONOMY-DB</dblink-db>
+<dblink-oid>83332</dblink-oid>
+<dblink-relationship>unification</dblink-relationship>
+<dblink-URL>http://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&amp;id=83332</dblink-URL>
+</dblink>
+<rank>strain</rank>
+<strain-name datatype="string">H37Rv</strain-name>
+<synonym datatype="string">Mycobacterium tuberculosis H37Rv</synonym>
+<synonym datatype="string">Mycobacterium tuberculosis str. H37Rv</synonym>
+<synonym datatype="string">Mycobacterium tuberculosis strain H37Rv</synonym>
+<synonym datatype="string">Mycobacterium sp. H37Rv</synonym>
+</Organism>
+</species>
+<species><Organism ID="META:ORG-5993" class="true" detail="full" frameid="ORG-5993" orgid="META"><parent><Organism class="true" frameid="TAX-3702" orgid="META" resource="getxml?META:TAX-3702" /></parent>
+<common-name datatype="string">Arabidopsis thaliana</common-name>
+<rank>strain</rank>
+<strain-name datatype="string">col</strain-name>
+<synonym datatype="string">Arabidopsis thaliana col</synonym>
+</Organism>
+</species>
+<super-pathways><Pathway frameid="PWY-7622" orgid="META" resource="getxml?META:PWY-7622" /><Pathway frameid="PWY-5114" orgid="META" resource="getxml?META:PWY-5114" /><Pathway frameid="COLANSYN-PWY" orgid="META" resource="getxml?META:COLANSYN-PWY" /><Pathway frameid="PWY-7328" orgid="META" resource="getxml?META:PWY-7328" /></super-pathways>
+<synonym datatype="string">UDP-D-galactose biosynthesis</synonym>
+<taxonomic-range><Organism ID="META:TAX-2759" class="true" detail="full" frameid="TAX-2759" orgid="META"><parent><Organism class="true" frameid="TAX-131567" orgid="META" resource="getxml?META:TAX-131567" /></parent>
+<common-name datatype="string">Eukaryota</common-name>
+<dblink><dblink-db>NCBI-TAXONOMY-DB</dblink-db>
+<dblink-oid>2759</dblink-oid>
+<dblink-relationship>unification</dblink-relationship>
+<dblink-URL>http://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&amp;id=2759</dblink-URL>
+</dblink>
+<rank>superkingdom</rank>
+<synonym datatype="string">eukaryotes &lt;common name&gt;</synonym>
+<synonym datatype="string">eukaryotes</synonym>
+<synonym datatype="string">Eukaryotae</synonym>
+<synonym datatype="string">Eukarya</synonym>
+<synonym datatype="string">eucaryotes</synonym>
+<synonym datatype="string">Eucaryotae</synonym>
+<synonym datatype="string">Eucarya</synonym>
+</Organism>
+<Organism ID="META:TAX-2" class="true" detail="full" frameid="TAX-2" orgid="META"><parent><Organism class="true" frameid="TAX-131567" orgid="META" resource="getxml?META:TAX-131567" /></parent>
+<common-name datatype="string">Bacteria &lt;bacteria&gt;</common-name>
+<dblink><dblink-db>NCBI-TAXONOMY-DB</dblink-db>
+<dblink-oid>2</dblink-oid>
+<dblink-relationship>unification</dblink-relationship>
+<dblink-URL>http://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&amp;id=2</dblink-URL>
+</dblink>
+<rank>superkingdom</rank>
+<synonym datatype="string">eubacteria</synonym>
+<synonym datatype="string">Bacteria</synonym>
+</Organism>
+<Organism ID="META:TAX-2157" class="true" detail="full" frameid="TAX-2157" orgid="META"><parent><Organism class="true" frameid="TAX-131567" orgid="META" resource="getxml?META:TAX-131567" /></parent>
+<common-name datatype="string">Archaea</common-name>
+<dblink><dblink-db>NCBI-TAXONOMY-DB</dblink-db>
+<dblink-oid>2157</dblink-oid>
+<dblink-relationship>unification</dblink-relationship>
+<dblink-URL>http://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&amp;id=2157</dblink-URL>
+</dblink>
+<rank>superkingdom</rank>
+<synonym datatype="string">Metabacteria</synonym>
+<synonym datatype="string">Mendosicutes</synonym>
+<synonym datatype="string">Archaebacteria</synonym>
+</Organism>
+</taxonomic-range>
+</Pathway>
+</ptools-xml>

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -625,6 +625,19 @@ class ComplexFunctions(TestCase):
             member="HOMOMETHIONINE_c",
             container=[member.id for member in test_model.metabolites],
         )
+        # CASE 2: From string, Custom
+        test_model = Model(0)
+        test_string = "Custom_c, Custom metabolites, c, H20, 0 "
+        cr.add_metabolites(
+            model=test_model,
+            obj=test_string,
+            directory=dir_data,
+            database=None,
+        )
+        self.assertIn(
+            member="Custom_c",
+            container=[member.id for member in test_model.metabolites],
+        )
         # CASE 3: From List of strings
         test_model = Model(0)
         test_list = ["HOMOMETHIONINE, c", "MALTOSE, c"]
@@ -659,7 +672,6 @@ class ComplexFunctions(TestCase):
                 member=item,
                 container=[member.id for member in test_model.metabolites],
             )
-        # CASE 6:
 
     def test_add_reactions(self):
         # CASE 0: Missing arguments.
@@ -682,7 +694,7 @@ class ComplexFunctions(TestCase):
                 member=reaction,
                 container=[reaction.id for reaction in test_model.reactions],
             )
-        # CASE 2: From string
+        # CASE 2a: From string
         test_model = Model(0)
         cr.add_reactions(
             model=test_model,
@@ -694,6 +706,23 @@ class ComplexFunctions(TestCase):
             member="GLC_cb",
             container=[reaction.id for reaction in test_model.reactions],
         )
+        # CASE 2b: From string, custom metabolites
+        test_model = Model(0)
+        cr.add_reactions(
+            model=test_model,
+            obj="Custom_cb, Custom reaction|Custom_c:-1, Custom_b:1",
+            directory=dir_data,
+            database=None,
+        )
+        self.assertIn(
+            member="Custom_cb",
+            container=[reaction.id for reaction in test_model.reactions],
+        )
+        for metabolite in ["Custom_c", "Custom_b"]:
+            self.assertIn(
+                member=metabolite,
+                container=[meta.id for meta in test_model.metabolites],
+            )
         # CASE 3: From List of strings
         test_model = Model(0)
         test_list = [

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -182,6 +182,13 @@ class TestBiocyc(TestCase):
             first=test_dict["TRIOSEPISOMERIZATION-RXN"],
             second=("SEDOBISALDOL-RXN", "F16ALDOLASE-RXN"),
         )
+        # CASE 3: Single-reaction pathway
+        test_root = bc._get_xml_from_biocyc(
+            directory=dir_data, identifier="PWY-7344", database="META"
+        )
+        test_dict = bc.get_graph(root=test_root)
+        self.assertEqual(first=len(test_dict), second=1)
+        self.assertEqual(first=test_dict["UDPGLUCEPIM-RXN"], second=None)
 
     def test__parse_biocyc(self):
         # CASE 1: Compound


### PR DESCRIPTION
INFO: When trying to create custom reactions and metabolites  were not able to be created. Single-reaction pathways such as PWY-7344 in MetaCyc, were returning errors.
UPDATED: in creation.py, function _reaction_from_string will check if any HTTPError is raised and will try to create custom objects from it.
UPDATED: in retrieval.py, function get_data will raise and HTTPError if no database is passed (None)
UPDATED: in biocyc.py, old function removed and fix for single-reaction pathways added.
UPDATED: new test added in test_creation.py and test_parsing.py to check new behaviours. New Data added
UPDATED: cobramod uses now semantic versioning scheme. Actual version 0.1.6