### PR TITLE
Weekly test

### DIFF
--- a/.github/workflows/test-build-and-publish.yml
+++ b/.github/workflows/test-build-and-publish.yml
@@ -2,6 +2,9 @@ name: Test build and publish Cobramod to PyPI
 on:
   workflow_dispatch:
 
+  schedule:
+    - cron: "0 5 * * 1"
+
   pull_request:
     types: [ opened, synchronize, reopened, closed ]
     branches:
@@ -60,7 +63,7 @@ jobs:
   build-publish:
     needs: [lint-format, types, test]
     name: Build and publish the package to TestPyPI
-    if: github.event.pull_request.merged == true
+    if: ${{ github.event.pull_request.merged == 'true' && github.event_name != 'schedule'}}
     runs-on: ubuntu-latest
 
     steps:

--- a/src/cobramod/test.py
+++ b/src/cobramod/test.py
@@ -5,15 +5,26 @@ This module creates the textbook models for testing. These are based on the
 original model "e_coli_core" from BiGG database, which are also included in
 COBRApy.
 """
+import gzip
+
+from importlib_resources import open_binary, files, as_file
 from pathlib import Path
 
-from cobra.io import read_sbml_model
-from cobra.test import create_test_model
+from cobra.io import read_sbml_model, validate_sbml_model
+import cobra.data
 
 # This is the directory where the textbook models are located.
 data_dir = Path(__file__).resolve().parent.joinpath("data")
 # These are the three posibilities
-textbook = create_test_model(model_name="textbook")
+
+try:
+    textbook
+except NameError:
+    textbook_raw = files(cobra.data).joinpath("textbook.xml")
+    with as_file(textbook_raw) as textbookXML:
+        textbook = read_sbml_model(str(textbookXML))
+
+
 textbook_biocyc = read_sbml_model(
     filename=str(data_dir.joinpath("textbook_biocyc.sbml"))
 )


### PR DESCRIPTION
The Github action 'test-build-and-publish' is executed on Mondays at 5 am so that installation problems are reported automatically.