### PR TITLE
Adjustment of flake8 settings

### DIFF
--- a/.toml
+++ b/.toml
@@ -1,5 +1,5 @@
 [flake8]
-extend-ignore = E203
+extend-ignore = E203, W503
 max-line-length = 79
 max-complexity = 18
 select = B,C,E,F,W,T4,B9


### PR DESCRIPTION
Changed behavior of flake8 caused the test to fail. Adding W503 to the ignored errors fixes this. W503 is currently the recommended way according to PEP8.