### PR TITLE
fixed the bug that pandas DataFrame deprecated the append function

### DIFF
--- a/src/cobramod/parsing/base.py
+++ b/src/cobramod/parsing/base.py
@@ -144,8 +144,8 @@ class BaseParser(ABC):
             BaseParser._get_database_version(directory=directory)
 
         assert isinstance(BaseParser.database_version, pd.DataFrame)
-        BaseParser.database_version = BaseParser.database_version.append(
-            {"orgid": database, "version": version}, ignore_index=True
+        BaseParser.database_version = pd.concat(
+            [BaseParser.database_version, pd.DataFrame({"orgid": [database], "version": [version]})], ignore_index=True
         )
 
         BaseParser.database_version.to_csv(


### PR DESCRIPTION
The newer pandas package deprecated the append function for dataframes since version 1.4.0. I just changed it to concat as suggested by pandas doc.