### PR TITLE
Reformatting with ruff@0.4.2.

### DIFF
--- a/src/cobramod/__init__.py
+++ b/src/cobramod/__init__.py
@@ -31,6 +31,7 @@ INFO. Read the documentation of logging for more information.
 
 For a list of databases, load variable :obj:`cobramod.available_databases`
 """
+
 from cobramod.core.creation import (
     add_metabolites,
     add_reactions,

--- a/src/cobramod/core/creation.py
+++ b/src/cobramod/core/creation.py
@@ -5,6 +5,7 @@ This module handles the creation of COBRApy's objects
 :class:`cobra.core.reaction.Reaction`. Dictionaries containing the data of a
 given database are used.
 """
+
 from __future__ import annotations
 
 from contextlib import suppress

--- a/src/cobramod/core/extension.py
+++ b/src/cobramod/core/extension.py
@@ -8,6 +8,7 @@ Most important functions:
 - test_non_zero_flux: Checks that the given reaction in a model is active and
     gives a non-zero flux.
 """
+
 from __future__ import annotations
 
 from contextlib import suppress

--- a/src/cobramod/core/genes.py
+++ b/src/cobramod/core/genes.py
@@ -3,6 +3,7 @@
 This module is responsible for the creation of COBRApy Genes from the parsed
 data of the specific parsers.
 """
+
 from typing import Any
 
 import cobra.core as cobra_core

--- a/src/cobramod/core/graph.py
+++ b/src/cobramod/core/graph.py
@@ -9,6 +9,7 @@ build_graph: From given dictionary with Parent-reaction:children-reaction,
 return the corresponding non-cyclic directed graph.
 
 """
+
 from __future__ import annotations
 
 from collections import Counter

--- a/src/cobramod/core/pathway.py
+++ b/src/cobramod/core/pathway.py
@@ -6,6 +6,7 @@ The new class :class:`cobramod.pathway.Pathway" is child derived from
 - solution: Obtain the solution for the specific members.
 - visualize: get a :class:`escher.Builder` for that specific Pathway.
 """
+
 from __future__ import annotations
 
 import warnings

--- a/src/cobramod/core/summary.py
+++ b/src/cobramod/core/summary.py
@@ -3,6 +3,7 @@
 This module is responsible for the short summary in the command
 line and for other summaries in different formats.
 """
+
 from __future__ import annotations
 from pathlib import Path
 from typing import Union, Optional

--- a/src/cobramod/debug.py
+++ b/src/cobramod/debug.py
@@ -7,6 +7,7 @@ will results in different files. The default level is set to INFO.
 
 The name of logger variable is `debug_log`
 """
+
 import datetime as dt
 import logging
 from pathlib import Path

--- a/src/cobramod/error.py
+++ b/src/cobramod/error.py
@@ -3,6 +3,7 @@
 This module creates special errors for CobraMod. Read each error for their
 explanation.
 """
+
 from cobramod.debug import debug_log
 
 

--- a/src/cobramod/parsing/bigg.py
+++ b/src/cobramod/parsing/bigg.py
@@ -10,6 +10,7 @@ acquired
 
 They change identifiers depending on the model given. BiGG have multiple models
 """
+
 from __future__ import annotations
 
 from contextlib import suppress

--- a/src/cobramod/parsing/biocyc.py
+++ b/src/cobramod/parsing/biocyc.py
@@ -7,6 +7,7 @@ The possible type of data that can be downloaded:
 - Reactions: Can have the words "RXN" in the identifier. Enzymes can sometimes
 be used instead. The gene information for the reactions is included if found.
 """
+
 from __future__ import annotations
 
 import urllib.parse

--- a/src/cobramod/parsing/db_version.py
+++ b/src/cobramod/parsing/db_version.py
@@ -6,6 +6,7 @@ obtaining and comparing the version from the obtained metabolic data.
 It uses the same structure of using a Singleton for the configuration in
 COBRApy
 """
+
 from pathlib import Path
 from typing import Optional, Union
 

--- a/src/cobramod/parsing/kegg.py
+++ b/src/cobramod/parsing/kegg.py
@@ -8,6 +8,7 @@ The possible type of data that can be downloaded:
 gene information for reactions is also included if the specie is specified
 - Module Pathways: Identifiers that start with the letter M, e.g M00001
 """
+
 from __future__ import annotations
 
 from contextlib import suppress

--- a/src/cobramod/parsing/plantcyc.py
+++ b/src/cobramod/parsing/plantcyc.py
@@ -3,6 +3,7 @@
 The main functions to parse Metabolites and Reactions are found in the module
 Biocyc
 """
+
 import urllib.parse
 import xml.etree.ElementTree as et
 from pathlib import Path

--- a/src/cobramod/parsing/solcyc.py
+++ b/src/cobramod/parsing/solcyc.py
@@ -3,6 +3,7 @@
 The main functions to parse Metabolites and Reactions are found in the module
 Biocyc
 """
+
 import urllib.parse
 import xml.etree.ElementTree as et
 from pathlib import Path

--- a/src/cobramod/retrieval.py
+++ b/src/cobramod/retrieval.py
@@ -9,6 +9,7 @@ Additionally, this package includes high level functions such as `get_data`,
 `file_to_Data_class` or `get_response` that handles the data retrieval or
 convertion
 """
+
 from __future__ import annotations
 
 import json
@@ -196,9 +197,11 @@ class Data:
             )
             info_response.raise_for_status()
 
-            with path.parents[1].joinpath("database_version").open(
-                mode="w+"
-            ) as f:
+            with (
+                path.parents[1]
+                .joinpath("database_version")
+                .open(mode="w+") as f
+            ):
                 f.write(info_response.text)
             version = info_response.json().get("bigg_models_version")
 

--- a/src/cobramod/test.py
+++ b/src/cobramod/test.py
@@ -4,6 +4,7 @@ This module creates the textbook models for testing. These are based on the
 original model "e_coli_core" from BiGG database, which are also included in
 COBRApy.
 """
+
 import pkg_resources
 from cobra.io import read_sbml_model
 

--- a/src/cobramod/utils.py
+++ b/src/cobramod/utils.py
@@ -6,6 +6,7 @@ example:
 
  - check_imbalance: Check for unbalanced reactions.
 """
+
 import io
 from pathlib import Path
 from re import match

--- a/src/cobramod/visualization/converter.py
+++ b/src/cobramod/visualization/converter.py
@@ -23,6 +23,7 @@ visualizations.
 - visualize: Saves Escher visualization as a HTML and return the Escher
 Builder.
 """
+
 import fileinput
 import math
 from collections import UserDict, namedtuple

--- a/src/cobramod/visualization/debug.py
+++ b/src/cobramod/visualization/debug.py
@@ -7,6 +7,7 @@ Configures the debug logging tool. The format follows the syntax: `(asctime)
 
 The name of logger variable is `visualization`
 """
+
 import datetime as dt
 import logging
 from pathlib import Path

--- a/src/cobramod/visualization/items.py
+++ b/src/cobramod/visualization/items.py
@@ -10,6 +10,7 @@ the position of all dots in the canvas.
 - Reaction: Represents a reaction. They contain the needed segments for the
 visualization of the pathway.
 """
+
 from contextlib import suppress
 from collections import UserDict
 from typing import Any

--- a/src/cobramod/visualization/mapping.py
+++ b/src/cobramod/visualization/mapping.py
@@ -6,6 +6,7 @@ used in Escher. The main function is
 is lineal and creates the representation in a matrix. In case of cyclic path,
 it will cut it.
 """
+
 from itertools import chain
 from typing import Dict, List
 

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -9,6 +9,7 @@ separated in:
 - SimpleFunctions: Creation of objects
 - ComplexFunctions: Functions, that uses multiple simple functions.
 """
+
 import unittest
 from logging import DEBUG
 from pathlib import Path

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -10,6 +10,7 @@ sequences and their corresponding flux test.
 - AddingPathways: Functions, that manage the addition of Pathways into the
 metabolic models.
 """
+
 import logging
 import unittest
 from pathlib import Path

--- a/tests/test_genes.py
+++ b/tests/test_genes.py
@@ -4,6 +4,7 @@
 In this module, the creation of genes for multiple function and their behavior
 are checked
 """
+
 import logging
 import unittest
 from pathlib import Path

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -4,6 +4,7 @@
 In this modules, the new algorithm is tested. The TestCase GraphTesting checks
 that the behavior of all important functions works as intended
 """
+
 import unittest
 from pathlib import Path
 from typing import Any

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,6 +7,7 @@ examples should simulate real cases. There are two test:
 - ShortModel: This should utilize the textbook_biocyc model from cobramod.
 - LargeModel: Uses a real GEM
 """
+
 import unittest
 from pathlib import Path
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -10,6 +10,7 @@ the different databases. The module is separated according to the databases:
 - TestPlantCyc: For PlantCyc
 - TestSolcyc: For SolCyc
 """
+
 import unittest
 from pathlib import Path
 

--- a/tests/test_pathway.py
+++ b/tests/test_pathway.py
@@ -5,6 +5,7 @@ This module includes the TestCase TestGroup. This checks the behavior of the
 new child of :obj:`cobra.core.group.Group` "Pathway". This new class is able
 to use Escher for its visualizations.
 """
+
 import unittest
 from json import loads
 from pathlib import Path

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -3,6 +3,7 @@
 Unit-test for data retrieval and Data version configuration. It checks that
 the files are loaded and saved properly
 """
+
 import logging
 import shutil
 import tempfile

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -4,6 +4,7 @@
 This modules checks functions responsable for the creation of txt, csv and xlsx
 files.
 """
+
 import tempfile
 from pathlib import Path
 from unittest import TestCase, main

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -1,6 +1,7 @@
 """
 Check if models are available
 """
+
 import unittest
 from pathlib import Path
 

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -6,6 +6,7 @@ This module includes two TestCases:
 - TestItems: Creation and behavior of JSON objects for the Escher-schema
 - TestJsonDictionary: Testing the methods inside the JsonDictionary
 """
+
 import unittest
 from contextlib import suppress
 from pathlib import Path


### PR DESCRIPTION
Newer versions of ruff demand an empty line between the docstrings module and the first import. This is the only change in a majority of files.