### PR TITLE
BUGFIX: Force-directed graph interactions not reliably working

### DIFF
--- a/js/force_graph.ts
+++ b/js/force_graph.ts
@@ -1,59 +1,66 @@
 import ForceGraph3D from '3d-force-graph';
 
-function render({ model, el }: { model: DOMWidgetModel; el: HTMLElement; }) {
+function render({model, el}: { model: DOMWidgetModel; el: HTMLElement; }) {
 
-    let cell = el.getBoundingClientRect()
+    let elem = document.createElement("div");
+    el.appendChild(elem);
+    let Graph: any;
 
-      let elem = document.createElement("div");
-      el.appendChild(elem);
-        let graph_data = JSON.parse(model.get("_model_rep"))
-        let Graph = ForceGraph3D()(elem)
-          .graphData(graph_data)
-          .nodeLabel("id")
-          .linkOpacity(1)
-          .linkAutoColorBy("value")
-          .linkDirectionalParticles(1)
-          .linkDirectionalParticleSpeed(d => d["value"] * 0.001)
-          .linkDirectionalParticleWidth(4)
-          .warmupTicks(100)
-          .cooldownTicks(0)
-          .width(cell.width)
-          .height(cell.width/2)
+    // wait until el is finished and has a size
+    const ro = new ResizeObserver((entries) => {
+        for (const entry of entries) {
+            const width = entry.contentRect.width;
+            if (width > 0) {
+                if (!Graph) {
+                    let graph_data = JSON.parse(model.get("_model_rep"))
+                    Graph = new ForceGraph3D(elem)
+                        .graphData(graph_data)
+                        .nodeLabel("id")
+                        .linkOpacity(1)
+                        .linkAutoColorBy("value")
+                        .linkDirectionalParticles(1)
+                        .linkDirectionalParticleSpeed(d => d["value"] * 0.001)
+                        .linkDirectionalParticleWidth(4)
+                        .warmupTicks(100)
+                        .cooldownTicks(0)
+                        .width(width)
+                        .height(width / 2)
 
-        model.on("change:_model_rep", () => {
+                    model.on("change:_model_rep", () => {
+                        Graph.graphData(JSON.parse(model.get("_model_rep")))
+                    });
 
-             Graph.graphData(JSON.parse(model.get("_model_rep")))
-
-        });
-
-        model.on("msg:custom", msg => {
-        switch (msg.type) {
-          case "create_layout":
-                let nodes = {}
-                Graph.graphData().nodes.forEach((n) => {
-                    nodes[n.id] = {"x": n.x, "y": n.y, "z": n.z};
-                });
-                model.send({ type: "layout", positions: nodes });
-                break;
-          case "load_layout":
-                let positions = msg.positions;
-                Graph.graphData().nodes.forEach((n) => {
-                    let pos = positions[n.id];
-                    n.fx = pos.x;
-                    n.fy = pos.y;
-                    n.fz = pos.z;
-                });
-                Graph.cooldownTicks(1)
-                Graph.d3ReheatSimulation()
-
-
-
-                break;
-
-          default:
-                console.log(`Unknown ${msg}.`);
+                    model.on("msg:custom", msg => {
+                        switch (msg.type) {
+                            case "create_layout":
+                                let nodes = {}
+                                Graph.graphData().nodes.forEach((n) => {
+                                    nodes[n.id] = {"x": n.x, "y": n.y, "z": n.z};
+                                });
+                                model.send({type: "layout", positions: nodes});
+                                break;
+                            case "load_layout":
+                                let positions = msg.positions;
+                                Graph.graphData().nodes.forEach((n) => {
+                                    let pos = positions[n.id];
+                                    n.fx = pos.x;
+                                    n.fy = pos.y;
+                                    n.fz = pos.z;
+                                });
+                                Graph.cooldownTicks(1)
+                                Graph.d3ReheatSimulation()
+                                break;
+                            default:
+                                console.log(`Unknown ${msg}.`);
+                        }
+                    });
+                } else {
+                    Graph.width(width).height(width / 2);
+                }
+            }
         }
-       });
-    }
+    });
+    ro.observe(el);
+}
 
-    export default { render };
+export default {render};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cobramod",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "scripts": {
     "start": "jupyter lab --config ./ui-tests/jupyter_server_config.py",
     "start:detached": "jlpm start&",

--- a/src/cobramod/__init__.py
+++ b/src/cobramod/__init__.py
@@ -38,7 +38,7 @@ from cobramod.core.creation import (
     create_object,
 )
 from cobramod.core.crossreferences import add_crossreferences
-from cobramod.core.extension import test_non_zero_flux, add_pathway
+from cobramod.core.extension import add_pathway, test_non_zero_flux
 from cobramod.core.pathway import Pathway, model_convert
 from cobramod.retrieval import get_data
 
@@ -54,4 +54,4 @@ __all__ = [
     "add_crossreferences",
 ]
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/src/cobramod/core/pathway.py
+++ b/src/cobramod/core/pathway.py
@@ -386,8 +386,9 @@ class Pathway(cobra_core.Group):
 <td>{self.name}</td> </tr> <tr> <td><strong>Memory address</strong></td>
 <td>0x0{id(self)}</td> </tr> <tr> <td><strong>Reactions involved</strong></td>
 <td> <p>{", ".join([rxn.id for rxn in self.members])}</p> </td> </tr> <tr>
-<td><strong>Genes involved<br /></strong></td> <td> <p>{", ".join([gene.id for
-rxn in self.members for gene in rxn.genes])}</p> </td> </tr> <tr>
+<td><strong>Genes involved<br /></strong></td> <td> <p>{
+            ", ".join([gene.id for rxn in self.members for gene in rxn.genes])
+        }</p> </td> </tr> <tr>
 <td><strong>Visualization attributes</strong></td> <td> <ul> <li>vertical =
 {self.vertical}</li> <li>color_negative = {self.color_negative}</li>
 <li>color_positive = {self.color_positive}</li> <li>color_quantile =

--- a/src/cobramod/core/summary.py
+++ b/src/cobramod/core/summary.py
@@ -356,28 +356,28 @@ def summary(
         + "|"
         + ("=" * 19)
         + "*"
-        + "\n" "{:13} {:^7} | {:^7} {:10}".format(
+        + "\n{:13} {:^7} | {:^7} {:10}".format(
             "Reactions", len(additions.reactions), len(deletions.reactions), ""
         )
-        + "\n" "{:13} {:^7} | {:^7} {:10}".format(
+        + "\n{:13} {:^7} | {:^7} {:10}".format(
             "Metabolites",
             len(additions.metabolites),
             len(deletions.metabolites),
             "",
         )
-        + "\n" "{:13} {:^7} | {:^7} {:10}".format(
+        + "\n{:13} {:^7} | {:^7} {:10}".format(
             "Exchange", len(additions.exchanges), len(deletions.exchanges), ""
         )
-        + "\n" "{:13} {:^7} | {:^7} {:10}".format(
+        + "\n{:13} {:^7} | {:^7} {:10}".format(
             "Demand", len(additions.demands), len(deletions.demands), ""
         )
-        + "\n" "{:13} {:^7} | {:^7} {:10}".format(
+        + "\n{:13} {:^7} | {:^7} {:10}".format(
             "Sinks", len(additions.sinks), len(deletions.sinks), ""
         )
-        + "\n" "{:13} {:^7} | {:^7} {:10}".format(
+        + "\n{:13} {:^7} | {:^7} {:10}".format(
             "Genes", len(additions.genes), len(deletions.genes), ""
         )
-        + "\n" "{:13} {:^7} | {:^7} {:10}".format(
+        + "\n{:13} {:^7} | {:^7} {:10}".format(
             "Groups", len(additions.groups), len(deletions.groups), ""
         )
         + "\n"

--- a/src/cobramod/retrieval.py
+++ b/src/cobramod/retrieval.py
@@ -329,7 +329,7 @@ class Data:
 
         """
         identifier = replacement.get(self.identifier, self.identifier)
-        identifier = f"{identifier.replace('-','_')}_{compartment}"
+        identifier = f"{identifier.replace('-', '_')}_{compartment}"
 
         if self.mode == "Metabolite":
             try:

--- a/src/cobramod/utils.py
+++ b/src/cobramod/utils.py
@@ -143,7 +143,7 @@ def compare_type(first: Any, second: Any):
     """
     Returns True is both objects are the same type, else raise TypeError.
     """
-    if type(first) == type(second):
+    if type(first) is type(second):
         return True
     else:
         raise TypeError("Given objects are not the same type.")

--- a/tests/test_crossreferences.py
+++ b/tests/test_crossreferences.py
@@ -9,6 +9,8 @@ from unittest.mock import patch
 import pandas as pd
 from cobra import Metabolite, Reaction
 from cobra import __version__ as cobra_version
+from numpy import nan
+
 from cobramod import __version__ as cmod_version
 from cobramod.core.crossreferences import (
     add2dict_unique,
@@ -21,7 +23,6 @@ from cobramod.core.crossreferences import (
 )
 from cobramod.debug import debug_log
 from cobramod.parsing.db_version import DataVersionConfigurator
-from numpy import NaN
 
 debug_log.setLevel(DEBUG)
 data_conf = DataVersionConfigurator()
@@ -166,7 +167,7 @@ class TestCrossReferences(TestCase):
                     "ID": ["test1", "test2"],
                     "mnx_equation": ["test1", "test2"],
                     "reference": ["test1", "test2"],
-                    "classifs": [NaN, "test2"],
+                    "classifs": [nan, "test2"],
                     "is_balanced": ["test1", "test2"],
                     "is_transport": ["test1", "test2"],
                 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,9 @@ import anywidget from "@anywidget/vite";
 import license from 'rollup-plugin-license';
 
 export default defineConfig({
+	resolve: {
+		dedupe: ['three'],
+	},
 	build: {
 		outDir: "./src/cobramod/static",
 		lib: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"3d-force-graph@^1.73.3":
+"3d-force-graph@^1.79.1":
   version "1.79.1"
   resolved "https://registry.yarnpkg.com/3d-force-graph/-/3d-force-graph-1.79.1.tgz#f5eabaf6d7077037f6cba69fc9cb94d51624628f"
   integrity sha512-iscIVt4jWjJ11KEEswgOIOWk8Ew4EFKHRyERJXJ0ouycqzHCtWwb9E5imnxS5rYF1f1IESkFNAfB+h3EkU0Irw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,15 +3,15 @@
 
 
 "3d-force-graph@^1.73.3":
-  version "1.73.3"
-  resolved "https://registry.yarnpkg.com/3d-force-graph/-/3d-force-graph-1.73.3.tgz#72c4c2dce7a40aae1e3de0cf4582abb330352e5f"
-  integrity sha512-azb65Lwn2yr/fJ4+qrxjmstVxogjzwJIZL/fdboCKBg6ph/FLW+xdvYFEBZW92XxBn1C8yRKS3d2VkVT3BzLSw==
+  version "1.79.1"
+  resolved "https://registry.yarnpkg.com/3d-force-graph/-/3d-force-graph-1.79.1.tgz#f5eabaf6d7077037f6cba69fc9cb94d51624628f"
+  integrity sha512-iscIVt4jWjJ11KEEswgOIOWk8Ew4EFKHRyERJXJ0ouycqzHCtWwb9E5imnxS5rYF1f1IESkFNAfB+h3EkU0Irw==
   dependencies:
     accessor-fn "1"
-    kapsule "1"
+    kapsule "^1.16"
     three ">=0.118 <1"
     three-forcegraph "1"
-    three-render-objects "^1.29"
+    three-render-objects "^1.35"
 
 "@anywidget/vite@^0.1.2":
   version "0.1.2"
@@ -42,11 +42,9 @@
     picocolors "^1.0.0"
 
 "@babel/runtime@^7.17.8":
-  version "7.24.4"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.4.tgz#de795accd698007a66ba44add6cc86542aff1edd"
-  integrity sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==
-  dependencies:
-    regenerator-runtime "^0.14.0"
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.6.tgz#d267a43cb1836dc4d182cce93ae75ba954ef6d2b"
+  integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
 
 "@codemirror/autocomplete@^6.0.0", "@codemirror/autocomplete@^6.3.2", "@codemirror/autocomplete@^6.5.1", "@codemirror/autocomplete@^6.7.1":
   version "6.16.0"
@@ -1751,10 +1749,10 @@
     "@stdlib/types" "^0.0.x"
     debug "^2.6.9"
 
-"@tweenjs/tween.js@18 - 23":
-  version "23.1.1"
-  resolved "https://registry.yarnpkg.com/@tweenjs/tween.js/-/tween.js-23.1.1.tgz#0ae28ed9c635805557f78c2626464018d5f1b5e2"
-  integrity sha512-ZpboH7pCPPeyBWKf8c7TJswtCEQObFo3bOBYalm99NzZarATALYCo5OhbCa/n4RQyJyHfhkdx+hNrdL5ByFYDw==
+"@tweenjs/tween.js@18 - 25":
+  version "25.0.0"
+  resolved "https://registry.yarnpkg.com/@tweenjs/tween.js/-/tween.js-25.0.0.tgz#7266baebcc3affe62a3a54318a3ea82d904cd0b9"
+  integrity sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==
 
 "@types/estree@1.0.5", "@types/estree@^1.0.0":
   version "1.0.5"
@@ -1795,9 +1793,9 @@
   integrity sha512-ejerrPMBXzYms6Ks+Gb7cdXtdncmT0xwIKNsc0c/SxhEa0HVY5jdvLUegYE91p7CQJpCnXOD/r2CvViN8txLLA==
 
 accessor-fn@1:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/accessor-fn/-/accessor-fn-1.5.0.tgz#9353e10194da404366657f47177cd9bcb4463ee7"
-  integrity sha512-dml7D96DY/K5lt4Ra2jMnpL9Bhw5HEGws4p1OAIxFFj9Utd/RxNfEO3T3f0QIWFNwQU7gNxH9snUfqF/zNkP/w==
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/accessor-fn/-/accessor-fn-1.5.3.tgz#5e2549d291d4ac022f532da9a554358dc525b0f7"
+  integrity sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==
 
 ajv@^8.12.0:
   version "8.12.0"
@@ -2158,9 +2156,9 @@ d3-ease@1:
   integrity sha512-lx14ZPYkhNx0s/2HX5sLFUI3mbasHjSSpwO/KaaNACweVwxUruKyWVcb293wMv1RqTPZyZ8kSZ2NogUZNcLOFQ==
 
 "d3-force-3d@2 - 3":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/d3-force-3d/-/d3-force-3d-3.0.5.tgz#9c8931b49acc3554f9110e128bc580cd3ab830f2"
-  integrity sha512-tdwhAhoTYZY/a6eo9nR7HP3xSW/C6XvJTbeRpR92nlPzH6OiE+4MliN9feuSFd0tPtEUo+191qOhCTWx3NYifg==
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/d3-force-3d/-/d3-force-3d-3.0.6.tgz#7ea4c26d7937b82993bd9444f570ed52f661d4aa"
+  integrity sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==
   dependencies:
     d3-binarytree "1"
     d3-dispatch "1 - 3"
@@ -2182,7 +2180,12 @@ d3-format@1:
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.4.5.tgz#374f2ba1320e3717eb74a9356c67daee17a7edb4"
   integrity sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==
 
-"d3-format@1 - 3", d3-format@^3.1.0:
+"d3-format@1 - 3":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.2.tgz#01fdb46b58beb1f55b10b42ad70b6e344d5eb2ae"
+  integrity sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==
+
+d3-format@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-3.1.0.tgz#9260e23a28ea5cb109e93b21a06e24e2ebd55641"
   integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
@@ -2223,9 +2226,9 @@ d3-interpolate@1:
     d3-color "1 - 3"
 
 d3-octree@1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/d3-octree/-/d3-octree-1.0.2.tgz#b39026b82701e45c7163e34ee056dc492035a017"
-  integrity sha512-Qxg4oirJrNXauiuC94uKMbgxwnhdda9xRLl9ihq45srlJ4Ga3CSgqGcAL8iW7N5CIv4Oz8x3E734ulxyvHPvwA==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-octree/-/d3-octree-1.1.0.tgz#f07e353b76df872644e7130ab1a74c5ef2f4287e"
+  integrity sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==
 
 d3-path@^3.1.0:
   version "3.1.0"
@@ -2283,6 +2286,11 @@ d3-selection@1, d3-selection@^1.0.3, d3-selection@^1.1.0:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.4.2.tgz#dcaa49522c0dbf32d6c1858afc26b6094555bc5c"
   integrity sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==
+
+"d3-selection@2 - 3":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-3.0.0.tgz#c25338207efa72cc5b9bd1458a1a41901f1e1b31"
+  integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
 
 d3-shape@^3.2.0:
   version "3.2.0"
@@ -2350,12 +2358,12 @@ d3-zoom@^1.7.3:
     d3-selection "1"
     d3-transition "1"
 
-data-joint@1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/data-joint/-/data-joint-1.3.1.tgz#d134950322c90f531e81bbbe8454277549031466"
-  integrity sha512-tMK0m4OVGqiA3zkn8JmO6YAqD8UwJqIAx4AAwFl1SKTtKAqcXePuT+n2aayiX9uITtlN3DFtKKTOxJRUc2+HvQ==
+data-bind-mapper@1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/data-bind-mapper/-/data-bind-mapper-1.0.3.tgz#275e55fd170331b1146479f3c7eb4256b8239481"
+  integrity sha512-QmU3lyEnbENQPo0M1F9BMu4s6cqNNp8iJA+b/HP2sSb7pf3dxwF3+EP1eO69rwBfH9kFJ1apmzrtogAmVt2/Xw==
   dependencies:
-    index-array-by "^1.4.0"
+    accessor-fn "1"
 
 debug@^2.6.9:
   version "2.6.9"
@@ -2587,6 +2595,15 @@ find-up@^5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
+float-tooltip@^1.7:
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/float-tooltip/-/float-tooltip-1.7.5.tgz#7083bf78f0de5a97f9c2d6aa8e90d2139f34047f"
+  integrity sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==
+  dependencies:
+    d3-selection "2 - 3"
+    kapsule "^1.16"
+    preact "10"
+
 follow-redirects@^1.0.0:
   version "1.15.6"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
@@ -2807,11 +2824,6 @@ indent-string@^5.0.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-5.0.0.tgz#4fd2980fccaf8622d14c64d694f4cf33c81951a5"
   integrity sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==
 
-index-array-by@^1.4.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/index-array-by/-/index-array-by-1.4.1.tgz#425f26cf0c744a47ebadf47366692e52043cf17b"
-  integrity sha512-Zu6THdrxQdyTuT2uA5FjUoBEsFHPzHcPIj18FszN6yXKHxSfGcR4TPLabfuT//E25q1Igyx9xta2WMvD/x9P/g==
-
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -2941,10 +2953,10 @@ jsonpointer@^5.0.1:
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-5.0.1.tgz#2110e0af0900fd37467b5907ecd13a7884a1b559"
   integrity sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==
 
-kapsule@1:
-  version "1.14.5"
-  resolved "https://registry.yarnpkg.com/kapsule/-/kapsule-1.14.5.tgz#c0bc7c1d4c693ee2647182e5b4ffbf95a4d65f72"
-  integrity sha512-H0iSpTynUzZw3tgraDmReprpFRmH5oP5GPmaNsurSwLx2H5iCpOMIkp5q+sfhB4Tz/UJd1E1IbEE9Z6ksnJ6RA==
+kapsule@^1.16:
+  version "1.16.3"
+  resolved "https://registry.yarnpkg.com/kapsule/-/kapsule-1.16.3.tgz#5684ed89838b6658b30d0f2cc056dffc3ba68c30"
+  integrity sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==
   dependencies:
     lodash-es "4"
 
@@ -2981,7 +2993,12 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@4, lodash-es@^4.17.21:
+lodash-es@4:
+  version "4.17.23"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.23.tgz#58c4360fd1b5d33afc6c0bbd3d1149349b1138e0"
+  integrity sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==
+
+lodash-es@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
@@ -3123,10 +3140,10 @@ nanoid@^3.3.7:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
   integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
 
-ngraph.events@^1.0.0, ngraph.events@^1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/ngraph.events/-/ngraph.events-1.2.2.tgz#3ceb92d676a04a4e7ce60a09fa8e17a4f0346d7f"
-  integrity sha512-JsUbEOzANskax+WSYiAPETemLWYXmixuPAlmZmhIbIj6FH/WDgEGCGnRwUQBK0GjOnVm8Ui+e5IJ+5VZ4e32eQ==
+ngraph.events@^1.0.0, ngraph.events@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ngraph.events/-/ngraph.events-1.4.0.tgz#3153c0a5760172c744f7b2dbc5a3d8a72703e357"
+  integrity sha512-NeDGI4DSyjBNBRtA86222JoYietsmCXbs8CEB0dZ51Xeh4lhVl1y3wpWLumczvnha8sFQIW4E0vvVWwgmX2mGw==
 
 ngraph.forcelayout@3:
   version "3.3.1"
@@ -3138,11 +3155,11 @@ ngraph.forcelayout@3:
     ngraph.random "^1.0.0"
 
 ngraph.graph@20:
-  version "20.0.1"
-  resolved "https://registry.yarnpkg.com/ngraph.graph/-/ngraph.graph-20.0.1.tgz#579470d1d805583239704dc913e2095540aaf371"
-  integrity sha512-VFsQ+EMkT+7lcJO1QP8Ik3w64WbHJl27Q53EO9hiFU9CRyxJ8HfcXtfWz/U8okuoYKDctbciL6pX3vG5dt1rYA==
+  version "20.1.2"
+  resolved "https://registry.yarnpkg.com/ngraph.graph/-/ngraph.graph-20.1.2.tgz#903389a5370a864cb1a47c522f54994b38cb3923"
+  integrity sha512-W/G3GBR3Y5UxMLHTUCPP9v+pbtpzwuAEIqP5oZV+9IwgxAIEZwh+Foc60iPc1idlnK7Zxu0p3puxAyNmDvBd0Q==
   dependencies:
-    ngraph.events "^1.2.1"
+    ngraph.events "^1.4.0"
 
 ngraph.merge@^1.0.0:
   version "1.0.0"
@@ -3150,9 +3167,9 @@ ngraph.merge@^1.0.0:
   integrity sha512-5J8YjGITUJeapsomtTALYsw7rFveYkM+lBj3QiYZ79EymQcuri65Nw3knQtFxQBU1r5iOaVRXrSwMENUPK62Vg==
 
 ngraph.random@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ngraph.random/-/ngraph.random-1.1.0.tgz#5345c4bb63865c85d98ee6f13eab1395d8545a90"
-  integrity sha512-h25UdUN/g8U7y29TzQtRm/GvGr70lK37yQPvPKXXuVfs7gCm82WipYFZcksQfeKumtOemAzBIcT7lzzyK/edLw==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ngraph.random/-/ngraph.random-1.2.0.tgz#3864ffbb9971e920db6c5f33ce5abc3d2439e3d2"
+  integrity sha512-4EUeAGbB2HWX9njd6bP6tciN6ByJfoaAvmVL9QTaZSeXrW46eNGA9GajiXiPBbvFqxUWFkEbyo6x5qsACUuVfA==
 
 node-fetch@^2.6.7:
   version "2.7.0"
@@ -3309,6 +3326,11 @@ postcss@^8.3.11, postcss@^8.4.38:
     picocolors "^1.0.0"
     source-map-js "^1.2.0"
 
+preact@10:
+  version "10.29.0"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.29.0.tgz#a6e5858670b659c4d471c6fea232233e03b403e8"
+  integrity sha512-wSAGyk2bYR1c7t3SZ3jHcM6xy0lcBcDel6lODcs9ME6Th++Dx2KU+6D3HD8wMMKGA8Wpw7OMd3/4RGzYRpzwRg==
+
 preact@^8.2.1:
   version "8.5.3"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.5.3.tgz#78c2a5562fcecb1fed1d0055fa4ac1e27bde17c1"
@@ -3419,11 +3441,6 @@ redent@^4.0.0:
   dependencies:
     indent-string "^5.0.0"
     strip-indent "^4.0.0"
-
-regenerator-runtime@^0.14.0:
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
-  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
 regexp-match-indices@^1.0.2:
   version "1.0.2"
@@ -3717,35 +3734,36 @@ tabbable@^5.2.0:
   integrity sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==
 
 three-forcegraph@1:
-  version "1.41.13"
-  resolved "https://registry.yarnpkg.com/three-forcegraph/-/three-forcegraph-1.41.13.tgz#30108eea95d424ac3012650166c8e9a7b60a5bfa"
-  integrity sha512-tVBEnGSf0H5bL5dnebANFsjgLUDrwXXfYRXv3RfPgzuymDoo7sJRPdWIPyrkEgN0e09Hzvr4RLXkQ5FUlWpUzw==
+  version "1.43.1"
+  resolved "https://registry.yarnpkg.com/three-forcegraph/-/three-forcegraph-1.43.1.tgz#092cf26092e6c10fc03e11763cf7ef009bbf9685"
+  integrity sha512-lQnYPLvR31gb91mF5xHhU0jPHJgBPw9QB23R6poCk8Tgvz8sQtq7wTxwClcPdfKCBbHXsb7FSqK06Osiu1kQ5A==
   dependencies:
     accessor-fn "1"
     d3-array "1 - 3"
     d3-force-3d "2 - 3"
     d3-scale "1 - 4"
     d3-scale-chromatic "1 - 3"
-    data-joint "1"
-    kapsule "1"
+    data-bind-mapper "1"
+    kapsule "^1.16"
     ngraph.forcelayout "3"
     ngraph.graph "20"
     tinycolor2 "1"
 
-three-render-objects@^1.29:
-  version "1.29.4"
-  resolved "https://registry.yarnpkg.com/three-render-objects/-/three-render-objects-1.29.4.tgz#f609b73e6058ca703227f0f32674ee6ed6fb7d50"
-  integrity sha512-E6YwTN5zNsaMjo/5rosgnK44b1aq//3YJGJ5BxG9t7+euRm7ZAmNX3NIqFkoDhKtFC5WLoOxZjyNoq8Uc49gaA==
+three-render-objects@^1.35:
+  version "1.40.4"
+  resolved "https://registry.yarnpkg.com/three-render-objects/-/three-render-objects-1.40.4.tgz#bfd45ff08900ffc82a4fcf105fd1971c604f2bab"
+  integrity sha512-Ukpu1pei3L5r809izvjsZxwuRcYLiyn6Uvy3lZ9bpMTdvj3i6PeX6w++/hs2ZS3KnEzGjb6YvTvh4UQuwHTDJg==
   dependencies:
-    "@tweenjs/tween.js" "18 - 23"
+    "@tweenjs/tween.js" "18 - 25"
     accessor-fn "1"
-    kapsule "1"
+    float-tooltip "^1.7"
+    kapsule "^1.16"
     polished "4"
 
 "three@>=0.118 <1":
-  version "0.163.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.163.0.tgz#cbfefbfd64a1353ab7cc8bf0fc396ddca1875a49"
-  integrity sha512-HlMgCb2TF/dTLRtknBnjUTsR8FsDqBY43itYop2+Zg822I+Kd0Ua2vs8CvfBVefXkBdNDrLMoRTGCIIpfCuDew==
+  version "0.183.2"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.183.2.tgz#606e3195bf210ef8d1eaaca2ab8c59d92d2bbc18"
+  integrity sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==
 
 tinycolor2@1:
   version "1.6.0"


### PR DESCRIPTION
Users could not always interact with the force-directed graph visualization using right- and left-click. To fix this, we updated “3d-force-graph” to 1.79.1 and delayed graph initialization until the other elements were loaded.